### PR TITLE
Add config to force ignore deployment.toml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,15 +107,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>${maven.checkstyle.plugin.version}</version>
                 <dependencies>

--- a/src/main/java/org/wso2/config/mapper/ConfigConstants.java
+++ b/src/main/java/org/wso2/config/mapper/ConfigConstants.java
@@ -31,6 +31,7 @@ public class ConfigConstants {
 
     static final String ENCRYPT_SECRETS = "encryptSecrets";
     static final String OVERRIDE_CONFIGURATION_ALWAYS = "forceConfigUpdate";
+    static final String AVOID_CONFIGURATION_UPDATE = "avoidConfigUpdate";
     static final String SYSTEM_PROPERTY_PREFIX = "sys:";
     static final String ENVIRONMENT_VARIABLE_PREFIX = "env:";
 

--- a/src/main/java/org/wso2/config/mapper/ConfigParser.java
+++ b/src/main/java/org/wso2/config/mapper/ConfigParser.java
@@ -75,11 +75,13 @@ public class ConfigParser {
 
         ConfigPaths.setPaths(configFilePath, resourcesDir, outputDir);
         File deploymentConfigurationFile = new File(configFilePath);
+        if (Boolean.getBoolean(ConfigConstants.AVOID_CONFIGURATION_UPDATE)) {
+            return;
+        }
         if (!deploymentConfigurationFile.exists()) {
             // If Deployment.toml didn't exist don't start server.
             log.warn("deployment.toml not found at " + configFilePath);
             return;
-//            throw new FileNotFoundException("deployment.toml not found at " + configFilePath);
         }
         try {
             if (Boolean.getBoolean(ConfigConstants.OVERRIDE_CONFIGURATION_ALWAYS)) {


### PR DESCRIPTION
Ignore deployment.toml file forcefully by adding new config "avoidConfigUpdate".