### PR TITLE
Add option to avoid read hash changes

### DIFF
--- a/src/main/java/org/wso2/config/mapper/ConfigConstants.java
+++ b/src/main/java/org/wso2/config/mapper/ConfigConstants.java
@@ -32,6 +32,8 @@ public class ConfigConstants {
     static final String ENCRYPT_SECRETS = "encryptSecrets";
     static final String OVERRIDE_CONFIGURATION_ALWAYS = "forceConfigUpdate";
     static final String AVOID_CONFIGURATION_UPDATE = "avoidConfigUpdate";
+    static final String AVOID_CONFIGURATION_HASH_READ = "avoidConfigHashRead";
+
     static final String SYSTEM_PROPERTY_PREFIX = "sys:";
     static final String ENVIRONMENT_VARIABLE_PREFIX = "env:";
 

--- a/src/main/java/org/wso2/config/mapper/ConfigParser.java
+++ b/src/main/java/org/wso2/config/mapper/ConfigParser.java
@@ -118,7 +118,7 @@ public class ConfigParser {
                         // Log changed files.
                         configFileSet.getChangedFiles().
                                 forEach(path -> log.warn("Configurations Changed in :" + path));
-                        log.warn("Overriding files in configuration directory " + outputDir);
+                        log.debug("Overriding files in configuration directory " + outputDir);
                     }
                     if (referencesVariableChanged) {
                         log.warn("Configuration value changed in references, Overriding files in the " +
@@ -179,7 +179,7 @@ public class ConfigParser {
         Context context = new Context();
         Set<String> deployedFileSet = deploy(context, ConfigPaths.getOutputDir());
 
-        log.info("Writing Metadata Entries...");
+        log.debug("Writing Metadata Entries...");
         Set<String> entries = new HashSet<>(Arrays.asList(ConfigPaths.getTemplateFileDir(),
                                                           ConfigPaths.getInferConfigurationFilePath(),
                                                           ConfigPaths.getDefaultValueFilePath(),


### PR DESCRIPTION
Add option to avoid read hash changes in template and conf directory. Only check hash for deployment.toml file.