### PR TITLE
Adding a new configuration to enable External Vault Support for Carbon Configurations

### DIFF
--- a/src/main/java/org/wso2/config/mapper/ConfigConstants.java
+++ b/src/main/java/org/wso2/config/mapper/ConfigConstants.java
@@ -34,5 +34,6 @@ public class ConfigConstants {
     static final String AVOID_CONFIGURATION_UPDATE = "avoidConfigUpdate";
     static final String SYSTEM_PROPERTY_PREFIX = "sys:";
     static final String ENVIRONMENT_VARIABLE_PREFIX = "env:";
+    static final String RUNTIME_SECRETS = "runtime_secrets";
 
 }

--- a/src/main/java/org/wso2/config/mapper/ReferenceResolver.java
+++ b/src/main/java/org/wso2/config/mapper/ReferenceResolver.java
@@ -55,6 +55,7 @@ public class ReferenceResolver {
     private static final String PLACEHOLDER_SUFFIX = "}";
     private static final String PLAIN_TEXT_VALUE_PLACE_HOLDER_PREFIX = "[";
     private static final String PLAIN_TEXT_VALUE_PLACE_HOLDER_SUFFIX = "]";
+    private static final String RUNTIME_SECRETS_ENABLED = "enable";
 
     private ReferenceResolver() {
 
@@ -75,11 +76,11 @@ public class ReferenceResolver {
     /**
      * Resolves the placeholder strings.
      *
-     * @param templateData      template data
-     * @param secrets           map of secrets
-     * @param resolvedSystemProperties          map of resolved system properties
-     * @param resolvedEnvironmentVariables      map of resolved environment varialbles
-     * @throws ConfigParserException            Config parser exception
+     * @param templateData                 template data
+     * @param secrets                      map of secrets
+     * @param resolvedSystemProperties     map of resolved system properties
+     * @param resolvedEnvironmentVariables map of resolved environment varialbles
+     * @throws ConfigParserException Config parser exception
      */
     static void resolve(Map<String, Object> templateData, Map<String, String> secrets, Map<String,
             String> resolvedSystemProperties, Map<String, String> resolvedEnvironmentVariables)
@@ -227,6 +228,11 @@ public class ReferenceResolver {
                     PLACEHOLDER_SUFFIX);
             if (secretRefs != null) {
                 for (String secretRef : secretRefs) {
+                    if (Boolean.parseBoolean((String) secrets.get(RUNTIME_SECRETS_ENABLED))) {
+                        if (!secrets.containsKey(secretRef)) {
+                            secrets.put(secretRef, "");
+                        }
+                    }
                     Object secretValue = secrets.get(secretRef);
                     if (secretValue == null) {
                         throw new ConfigParserException("Secret references can't be resolved for " + secretRef);
@@ -298,12 +304,12 @@ public class ReferenceResolver {
                         CONF_PLACEHOLDER_PREFIX + key + PLACEHOLDER_SUFFIX),
                         Matcher.quoteReplacement(value.toString()));
                 context.put(k, existingValue);
-            } else if (existingValue instanceof  ArrayList) {
+            } else if (existingValue instanceof ArrayList) {
                 ArrayList<String> modifiedValueList = new ArrayList<>();
                 for (String item : (ArrayList<String>) existingValue) {
                     item = item.replaceAll(Pattern.quote(
                             CONF_PLACEHOLDER_PREFIX + key + PLACEHOLDER_SUFFIX),
-                                           Matcher.quoteReplacement(value.toString()));
+                            Matcher.quoteReplacement(value.toString()));
                     modifiedValueList.add(item);
                 }
                 context.put(k, modifiedValueList);

--- a/src/main/java/org/wso2/config/mapper/TomlParser.java
+++ b/src/main/java/org/wso2/config/mapper/TomlParser.java
@@ -126,8 +126,12 @@ class TomlParser {
 
         Map<String, String> context = new LinkedHashMap<>();
         TomlTable table = result.getTable(ConfigConstants.SECRET_PROPERTY_MAP_NAME);
+        TomlTable runtimeSecretsConfig = result.getTable(ConfigConstants.RUNTIME_SECRETS);
         if (table != null) {
             table.dottedKeySet().forEach(key -> context.put(key, table.getString(key)));
+        }
+        if (runtimeSecretsConfig != null) {
+            runtimeSecretsConfig.dottedKeySet().forEach(key -> context.put(key, runtimeSecretsConfig.getString(key)));
         }
         return context;
     }

--- a/src/test/java/org/wso2/config/mapper/ReferenceResolverTest.java
+++ b/src/test/java/org/wso2/config/mapper/ReferenceResolverTest.java
@@ -81,6 +81,7 @@ public class ReferenceResolverTest {
 
         Map secrets = new HashMap();
         secrets.put("b.c.d", "sssssss");
+        secrets.put("enable", "true");
         Map resolvedSystemProperties = new HashMap();
         Map resolvedEnvironmentVariables = new HashMap();
         ReferenceResolver.resolve(context, secrets, resolvedSystemProperties, resolvedEnvironmentVariables);
@@ -92,6 +93,7 @@ public class ReferenceResolverTest {
         Map resolvedSystemProperties = new HashMap();
         Map resolvedEnvironmentVariables = new HashMap();
         secrets.put("b.c.d", "[sssssss]");
+        secrets.put("enable", "false");
         try {
             ReferenceResolver.resolve(context, secrets, resolvedSystemProperties, resolvedEnvironmentVariables);
             Assert.fail();
@@ -105,7 +107,7 @@ public class ReferenceResolverTest {
         Map secrets = new HashMap();
         Map resolvedSystemProperties = new HashMap();
         Map resolvedEnvironmentVariables = new HashMap();
-
+        secrets.put("enable", "false");
         try {
             ReferenceResolver.resolve(context, secrets, resolvedSystemProperties, resolvedEnvironmentVariables);
             Assert.fail();


### PR DESCRIPTION
## Purpose
> According to the current implementation of the SecureVault which uses FileBaseSecretRepository as the inbuilt vault facility, it is required to define the secrets which are going to be used in the configurations in the form of aliases and their secret values and later they will get encrypted using ciphertool. Furthermore, since it is not required to encrypt secrets when connecting with external vaults, yet it has been added to the deployment. toml file with empty strings to satisfy the existing flow.
> 
> The purpose of this is to omit the use of secrets map inside the deployment. toml file when using external vaults to store the secrets which are being defined in the configuration files.

## Goals
> When there are secrets which use legacy secrets providers the secrets map should contain the aliases and it`s corresponding secrets.
> When it uses external vault configured based on the novel approach no secret map is required.
> When it uses both ways ( a legacy based and newly implemented way ), the parser will distinguish based on the configuration whether to access the secrets map or access any other configured vault.

## Approach
> To omit the defining of secrets in the configurations file, a new configuration property has been introduced.

>        [runtime_secrets]
>        enable = " true "
>
> With this configuration, there has been done a modification to the ConfigMapper.
During the processing of secrets from the parse result, the introduced property will also get added to the secrets map and when there is a particular element which has been masked by "$secret{}" annotation. It will get passed to the resolvedStringWithSecretPlaceholder() method which is inside the ReferenceResolver class along with the secrets map and based on the configured property and state of the secrets (whether the required secret resides in the secrets map or not) the masked value will get processed.
>
> When there are secrets which use external vaults then during resolving of the OMElement which contains the "$secret" annotation it will 1st check whether the secrets map initialized or else that particular alias will get added to the secrets map with an empty string and the resolving continues as in the previous implementation.  

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
>https://github.com/wso2/carbon-secvault/pull/71

## Test environment
> JDK version - 1.8
> Operating System - Ubuntu 18.04
