### PR TITLE
Bump gson version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@
         <version.checkstyle>7.8.2</version.checkstyle>
         <version.jinjava>2.6.0</version.jinjava>
         <version.cava-toml>0.5.0</version.cava-toml>
-        <version.com.google.code.gson>2.8.5</version.com.google.code.gson>
+        <version.com.google.code.gson>2.9.0</version.com.google.code.gson>
         <testng.verson>6.10</testng.verson>
         <orbit.version.commons.io>2.4.0.wso2v1</orbit.version.commons.io>
         <common.logging.version>1.2</common.logging.version>


### PR DESCRIPTION
## Purpose
Update gson version from 2.8.5 to 2.9.0

## Related Issue
- https://github.com/wso2/product-is/issues/17955
